### PR TITLE
Add `dns.override` flag

### DIFF
--- a/types.go
+++ b/types.go
@@ -16,6 +16,7 @@ type InterfaceConfig struct {
 }
 
 type DnsConfig struct {
+	Override    bool     `yaml:"override"`
 	Nameservers []string `yaml:"nameservers,flow,omitempty"`
 	Search      []string `yaml:"search,flow,omitempty"`
 }


### PR DESCRIPTION
Add `dns.override` flag

If `dns.override` is set, `dns.nameservers` should take precedence over the DHCP configured nameservers.
