### PR TITLE
delete the omitempty flag of the DHCP in InterfaceConfig

### DIFF
--- a/types.go
+++ b/types.go
@@ -9,7 +9,7 @@ type NetworkConfig struct {
 
 type InterfaceConfig struct {
 	Match       string            `yaml:"match,omitempty"`
-	DHCP        bool              `yaml:"dhcp,omitempty"`
+	DHCP        bool              `yaml:"dhcp"`
 	DHCPArgs    string            `yaml:"dhcp_args,omitempty"`
 	Address     string            `yaml:"address,omitempty"`
 	Addresses   []string          `yaml:"addresses,omitempty"`


### PR DESCRIPTION
when we set configure network interface with the following command
`$ sudo ros config set rancher.network.interfaces.eth1.dhcp false`
and to see whether it is configured corerctly with command `$ sudo ros
config get rancher.network.interfaces.eth1`.

we get nothing now. It is better to delete the omitempty flag and user
can see:

```
rancher:
  network:
    interfaces:
      eth1:
        dhcp: false
```

Signed-off-by: Wang Long long.wanglong@huawei.com
